### PR TITLE
test: replace goacc with go test for coverage checks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,11 +45,7 @@ jobs:
       - name: Send coverage
         uses: coverallsapp/github-action@v2
         with:
-          files: |
-            ./coverage.txt 
-            ./btcec/coverage.txt
-            ./btcutil/coverage.txt
-            ./btcutil/psbt/coverage.txt
+          files: ./coverage.txt ./btcec/coverage.txt ./btcutil/coverage.txt ./btcutil/psbt/coverage.txt
           format: golang
 
   test-race:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,17 +39,24 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v4
 
-      - name: Test
+      - name: Generate coverage info
         run: make unit-cover
+
+      # Copy coverage files to the root directory to fix "Permission denied" error
+      - name: Copy coverage files
+        run: |
+          cp ./btcec/coverage.txt coverage-btcec.txt
+          cp ./btcutil/coverage.txt coverage-btcutil.txt
+          cp ./btcutil/psbt/coverage.txt coverage-btcutil-psbt.txt
 
       - name: Send coverage
         uses: coverallsapp/github-action@v2
         with:
           files: |
-            ./coverage.txt 
-            ./btcec/coverage.txt
-            ./btcutil/coverage.txt
-            ./btcutil/psbt/coverage.txt
+            coverage.txt
+            coverage-btcec.txt
+            coverage-btcutil.txt
+            coverage-btcutil-psbt.txt
           format: golang
 
   test-race:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  release:
+    types:
+      - created
 
 env:
   # go needs absolute directories, using the $HOME variable doesn't work here.

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,9 @@
 name: Build and Test
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   # go needs absolute directories, using the $HOME variable doesn't work here.
@@ -43,7 +47,7 @@ jobs:
         with:
           files: |
             coverage.txt 
-            path-to-profile: btcec/coverage.txt
+            btcec/coverage.txt
             btcutil/coverage.txt
             btcutil/psbt/coverage.txt
           format: golang

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,24 +39,17 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v4
 
-      - name: Generate coverage info
+      - name: Test
         run: make unit-cover
-
-      # Copy coverage files to the root directory to fix "Permission denied" error
-      - name: Copy coverage files
-        run: |
-          cp ./btcec/coverage.txt coverage-btcec.txt
-          cp ./btcutil/coverage.txt coverage-btcutil.txt
-          cp ./btcutil/psbt/coverage.txt coverage-btcutil-psbt.txt
 
       - name: Send coverage
         uses: coverallsapp/github-action@v2
         with:
           files: |
-            coverage.txt
-            coverage-btcec.txt
-            coverage-btcutil.txt
-            coverage-btcutil-psbt.txt
+            ./coverage.txt 
+            ./btcec/coverage.txt
+            ./btcutil/coverage.txt
+            ./btcutil/psbt/coverage.txt
           format: golang
 
   test-race:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,25 +38,15 @@ jobs:
       - name: Test
         run: make unit-cover
 
-      - name: Send top-level coverage
-        uses: shogo82148/actions-goveralls@v1
+      - name: Send coverage
+        uses: coverallsapp/github-action@v2
         with:
-          path-to-profile: coverage.txt
-
-      - name: Send btcec
-        uses: shogo82148/actions-goveralls@v1
-        with:
-          path-to-profile: btcec/coverage.txt
-
-      - name: Send btcutil coverage
-        uses: shogo82148/actions-goveralls@v1
-        with:
-          path-to-profile: btcutil/coverage.txt
-
-      - name: Send btcutil coverage for psbt package
-        uses: shogo82148/actions-goveralls@v1
-        with:
-          path-to-profile: btcutil/psbt/coverage.txt
+          files: |
+            coverage.txt 
+            path-to-profile: btcec/coverage.txt
+            btcutil/coverage.txt
+            btcutil/psbt/coverage.txt
+          format: golang
 
   test-race:
     name: Unit race

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,10 +46,10 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           files: |
-            coverage.txt 
-            btcec/coverage.txt
-            btcutil/coverage.txt
-            btcutil/psbt/coverage.txt
+            ./coverage.txt 
+            ./btcec/coverage.txt
+            ./btcutil/coverage.txt
+            ./btcutil/psbt/coverage.txt
           format: golang
 
   test-race:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOIMPORTS_PKG := golang.org/x/tools/cmd/goimports
 
 GO_BIN := ${GOPATH}/bin
 LINT_BIN := $(GO_BIN)/golangci-lint
-GOACC_BIN := $(GO_BIN)/go-acc
+
 
 LINT_COMMIT := v1.18.0
 GOACC_VERSION := v0.2.7
@@ -15,8 +15,10 @@ DEPGET := cd /tmp && GO111MODULE=on go get -v
 GOBUILD := GO111MODULE=on go build -v
 GOINSTALL := GO111MODULE=on go install -v 
 DEV_TAGS := rpctest
-GOTEST_DEV = GO111MODULE=on go test -v -tags=$(DEV_TAGS)
+GOTEST_DEV = GO111MODULE=on go test -tags=$(DEV_TAGS)
 GOTEST := GO111MODULE=on go test -v
+
+GOACC_BIN := $(GOTEST_DEV) -coverprofile=coverage.txt -covermode=atomic
 
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
@@ -51,10 +53,6 @@ $(LINT_BIN):
 	@$(call print, "Fetching linter")
 	$(DEPGET) $(LINT_PKG)@$(LINT_COMMIT)
 
-$(GOACC_BIN):
-	@$(call print, "Fetching go-acc")
-	$(GOINSTALL) $(GOACC_PKG)@$(GOACC_VERSION)
-
 goimports:
 	@$(call print, "Installing goimports.")
 	$(DEPGET) $(GOIMPORTS_PKG)
@@ -84,7 +82,7 @@ unit:
 	cd btcutil; $(GOTEST_DEV) ./... -test.timeout=20m
 	cd btcutil/psbt; $(GOTEST_DEV) ./... -test.timeout=20m
 
-unit-cover: $(GOACC_BIN)
+unit-cover:
 	@$(call print, "Running unit coverage tests.")
 	$(GOACC_BIN) ./...
 	

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ unit-cover:
 	
 	# We need to remove the /v2 pathing from the module to have it work
 	# nicely with the CI tool we use to render live code coverage.
-	cd btcec; $(GOACC_BIN) ./...; sed -i.bak 's/v2\///g' coverage.txt
+	cd btcec; $(GOACC_BIN) ./...
 
 	cd btcutil; $(GOACC_BIN) ./...
 


### PR DESCRIPTION
Since go 1.20, `go test` produces valid coverage reports for our use case.

Replaced go-acc with go test for coverage tests.